### PR TITLE
Prepare Material You 0.1.1 patch release

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -1,5 +1,5 @@
 {
-	"gitSiteUrl": "https://github.com/liminal-hq/liminal-tauri-plugins/",
+	"gitSiteUrl": "https://github.com/liminal-hq/tauri-plugins-workspace/",
 	"pkgManagers": {
 		"javascript": {
 			"version": true,

--- a/.changes/material-you-docs-and-metadata-refresh.md
+++ b/.changes/material-you-docs-and-metadata-refresh.md
@@ -1,0 +1,11 @@
+---
+'material-you': patch
+'material-you-js': patch
+---
+
+Release updates for `material-you` and `material-you-js`:
+
+- Improves plugin metadata discoverability across npm and crates.io.
+- Updates plugin documentation with package links, install alternatives, and issue reporting guidance.
+- Fixes guest JavaScript bundle configuration warnings in Rollup output.
+- Aligns repository references and links with `tauri-plugins-workspace`.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "liminal-tauri-plugins",
+	"name": "tauri-plugins-workspace",
 	"version": "0.0.0",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
## Summary
- add a Covector patch change file for `material-you` and `material-you-js`
- align Covector `gitSiteUrl` with the current repository URL
- align workspace package name with `tauri-plugins-workspace`

## Why
- publishes recent material-you documentation and metadata improvements in a new patch release
- ensures release links and workspace naming are consistent with the current repository

## Validation
- run `npx -y pnpm@10.28.2 run covector:status -- --dry-run`
- confirm planned bumps: `material-you 0.1.0 -> 0.1.1` and `material-you-js 0.1.0 -> 0.1.1`
