### PR TITLE
Fix Covector release PR titles to include only released packages

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -103,6 +103,10 @@ jobs:
             }
 
             const pkgName = pkgMatch[1].trim();
+            if (/^version updates$/i.test(pkgName)) {
+              continue;
+            }
+
             let version = '';
 
             for (let j = i + 1; j < Math.min(i + 12, lines.length); j += 1) {
@@ -111,6 +115,10 @@ jobs:
                 version = verMatch[1].trim();
                 break;
               }
+            }
+
+            if (!version) {
+              continue;
             }
 
             releases.push({ pkgName, version });


### PR DESCRIPTION
## Summary
- ignore the non-package `Version Updates` heading in Covector release PR title parsing
- include only headings that resolve to a nearby package version block

## Why
- prevents false `... and 1 more` suffixes in release PR titles
- keeps automated release PR titles aligned with actual package releases

## Scope
- workflow title metadata parsing in `.github/workflows/covector-version-or-publish.yml`
