### PR TITLE
Extract xdg-portal and desktop-integration plugins from emoji-nook

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -67,6 +67,22 @@
 			"path": "./plugins/material-you",
 			"manager": "javascript"
 		},
+		"xdg-portal": {
+			"path": "./plugins/xdg-portal",
+			"manager": "rust"
+		},
+		"xdg-portal-js": {
+			"path": "./plugins/xdg-portal",
+			"manager": "javascript"
+		},
+		"desktop-integration": {
+			"path": "./plugins/desktop-integration",
+			"manager": "rust"
+		},
+		"desktop-integration-js": {
+			"path": "./plugins/desktop-integration",
+			"manager": "javascript"
+		},
 		"api-example": {
 			"path": "./examples/api/src-tauri",
 			"manager": "rust",

--- a/.changes/xdg-portal-desktop-integration-initial-release.md
+++ b/.changes/xdg-portal-desktop-integration-initial-release.md
@@ -1,0 +1,12 @@
+---
+'xdg-portal': minor
+'xdg-portal-js': minor
+'desktop-integration': minor
+'desktop-integration-js': minor
+---
+
+Release notes for the new `xdg-portal` and `desktop-integration` plugins, promoted from `liminal-hq/emoji-nook`:
+
+- `xdg-portal` bridges Tauri apps to the Linux `xdg-desktop-portal` D-Bus interfaces: desktop theme detection (colour scheme, accent colour, high contrast) via the Settings portal, and Wayland global shortcut binding via the GlobalShortcuts portal.
+- `desktop-integration` provides X11 window activation (`_NET_WM_USER_TIME` stamping via `gdkx11`) and a unified `DesktopIntegrationExt` trait that picks X11 direct shortcut binding or the Wayland portal automatically based on session type.
+- Both are Linux-only; see each plugin's `[package.metadata.platforms.support]` and README for details.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [workspace]
 members = [
   "plugins/material-you",
+  "plugins/xdg-portal",
+  "plugins/desktop-integration",
   "examples/api/src-tauri",
 ]
 # plugins/hdmv depends on libhdmv which is not available in CI.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ A collection of Tauri v2 plugins for building privacy-focused, local-first appli
 
 ## Plugins
 
-| Plugin                                 | Description                                       | Platforms        |
-| -------------------------------------- | ------------------------------------------------- | ---------------- |
-| `alarm-manager`                        | Native alarm scheduling with Android AlarmManager | Android          |
-| `time-prefs`                           | System time format detection                      | Desktop, Android |
-| [`material-you`](plugins/material-you) | Material You theming support                      | Android          |
-| `mobile-app-management`                | Mobile app lifecycle management                   | Android, iOS     |
+| Plugin                                               | Description                                               | Platforms        |
+| ---------------------------------------------------- | --------------------------------------------------------- | ---------------- |
+| `alarm-manager`                                      | Native alarm scheduling with Android AlarmManager         | Android          |
+| `time-prefs`                                         | System time format detection                              | Desktop, Android |
+| [`material-you`](plugins/material-you)               | Material You theming support                              | Android          |
+| `mobile-app-management`                              | Mobile app lifecycle management                           | Android, iOS     |
+| [`xdg-portal`](plugins/xdg-portal)                   | `xdg-desktop-portal` theming and global shortcuts         | Linux            |
+| [`desktop-integration`](plugins/desktop-integration) | X11 window activation and unified global-shortcut binding | Linux            |
 
 ## Installation
 

--- a/plugins/desktop-integration/Cargo.toml
+++ b/plugins/desktop-integration/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "tauri-plugin-desktop-integration"
+version = "0.2.0"
+description = "Desktop activation helpers for X11/Wayland window focus and global shortcuts"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+rust-version = { workspace = true }
+repository = { workspace = true }
+build = "build.rs"
+links = "tauri-plugin-desktop-integration"
+
+[package.metadata.platforms.support]
+windows = { level = "none", notes = "X11/Wayland activation helpers only" }
+linux = { level = "full", notes = "X11 window activation via gdkx11, Wayland global shortcuts via the portal" }
+macos = { level = "none", notes = "X11/Wayland activation helpers only" }
+android = { level = "none", notes = "X11/Wayland activation helpers only" }
+ios = { level = "none", notes = "X11/Wayland activation helpers only" }
+
+[lib]
+name = "tauri_plugin_desktop_integration"
+crate-type = ["staticlib", "cdylib", "rlib"]
+
+[dependencies]
+ashpd = { version = "0.9", default-features = false, features = ["tokio", "wayland"] }
+log = { workspace = true }
+raw-window-handle = "0.6"
+serde = { workspace = true }
+tauri = { workspace = true }
+tauri-plugin-global-shortcut = "2"
+tauri-plugin-xdg-portal = { path = "../xdg-portal", version = "0.2" }
+tokio = { version = "1", features = ["sync"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+gdk = "0.18"
+gdkx11 = "0.18"
+gtk = "0.18"
+
+[build-dependencies]
+tauri-plugin = { workspace = true, features = ["build"] }

--- a/plugins/desktop-integration/Cargo.toml
+++ b/plugins/desktop-integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-desktop-integration"
-version = "0.2.0"
+version = "0.0.0"
 description = "Desktop activation helpers for X11/Wayland window focus and global shortcuts"
 authors = { workspace = true }
 edition = { workspace = true }
@@ -28,7 +28,7 @@ raw-window-handle = "0.6"
 serde = { workspace = true }
 tauri = { workspace = true }
 tauri-plugin-global-shortcut = "2"
-tauri-plugin-xdg-portal = { path = "../xdg-portal", version = "0.2" }
+tauri-plugin-xdg-portal = { path = "../xdg-portal", version = "0.0.0" }
 tokio = { version = "1", features = ["sync"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/plugins/desktop-integration/README.md
+++ b/plugins/desktop-integration/README.md
@@ -1,0 +1,95 @@
+# @liminal-hq/plugin-desktop-integration
+
+Desktop activation helpers for Linux Tauri apps: native X11 window activation and a
+unified global-shortcut API that picks the right binding path (X11 direct grab vs.
+Wayland portal) automatically based on session type.
+
+- Requests native GTK window presentation with a real event timestamp and stamps
+  `_NET_WM_USER_TIME` through `gdkx11`, so fresh windows look like legitimate
+  user-driven activations under X11 window managers.
+- Wraps `tauri-plugin-global-shortcut` on X11 and
+  [`@liminal-hq/plugin-xdg-portal`](../xdg-portal)'s `GlobalShortcuts` portal binding
+  on Wayland behind one `DesktopIntegrationExt` trait, so calling apps don't need to
+  branch on session type themselves.
+- On non-Linux platforms, the activation helper is a documented no-op — see
+  [Platform Support](#platform-support).
+
+## Installation
+
+### Rust
+
+```toml
+[dependencies]
+tauri-plugin-desktop-integration = "0.2"
+
+# Alternatively with Git:
+tauri-plugin-desktop-integration = { git = "https://github.com/liminal-hq/tauri-plugins-workspace", branch = "main" }
+```
+
+### JavaScript
+
+```bash
+pnpm add @liminal-hq/plugin-desktop-integration
+```
+
+## Usage
+
+### Rust
+
+```rust
+use tauri_plugin_desktop_integration::DesktopIntegrationExt;
+
+fn main() {
+    tauri::Builder::default()
+        .plugin(tauri_plugin_desktop_integration::init())
+        .plugin(tauri_plugin_global_shortcut::Builder::new().build())
+        .plugin(tauri_plugin_xdg_portal::init())
+        .setup(|app| {
+            let handle = app.handle().clone();
+            handle.register_shortcut(
+                "your-app-toggle",   // stable Wayland portal session id
+                "Toggle Your App",   // shown in the compositor's shortcut dialog
+                "Alt+Shift+T",
+                move || { /* shortcut activated */ },
+            );
+            Ok(())
+        })
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}
+```
+
+On Wayland, the portal `BindShortcuts` call requires a parent window for its
+confirmation dialog. Call `set_shortcut_window(&window)` once your first window is
+shown to kick off the deferred binding, and listen for the `shortcut-binding-result`
+event to know when it resolves.
+
+### JavaScript
+
+```typescript
+import { desktopIntegration } from '@liminal-hq/plugin-desktop-integration';
+
+const complete = await desktopIntegration.checkShortcutBindingComplete();
+const error = await desktopIntegration.checkShortcutBindingError();
+```
+
+## Permissions
+
+This plugin requires these permissions:
+
+- `allow-check-shortcut-binding-complete`: Grants access to `check_shortcut_binding_complete`
+- `allow-check-shortcut-binding-error`: Grants access to `check_shortcut_binding_error`
+
+## Platform Support
+
+| Platform | Support Level | Notes                                                         |
+| -------- | ------------- | ------------------------------------------------------------- |
+| Windows  | None          | X11/Wayland activation helpers only                           |
+| Linux    | Full          | X11 activation via `gdkx11`, Wayland shortcuts via the portal |
+| macOS    | None          | X11/Wayland activation helpers only                           |
+| Android  | None          | X11/Wayland activation helpers only                           |
+| iOS      | None          | X11/Wayland activation helpers only                           |
+
+## Licence
+
+Apache-2.0 OR MIT

--- a/plugins/desktop-integration/README.md
+++ b/plugins/desktop-integration/README.md
@@ -20,7 +20,7 @@ Wayland portal) automatically based on session type.
 
 ```toml
 [dependencies]
-tauri-plugin-desktop-integration = "0.2"
+tauri-plugin-desktop-integration = "0.1"
 
 # Alternatively with Git:
 tauri-plugin-desktop-integration = { git = "https://github.com/liminal-hq/tauri-plugins-workspace", branch = "main" }

--- a/plugins/desktop-integration/api-iife.js
+++ b/plugins/desktop-integration/api-iife.js
@@ -1,0 +1,33 @@
+if ('__TAURI__' in window) {
+var __TAURI_PLUGIN_DESKTOP_INTEGRATION__ = (function (exports, core) {
+    'use strict';
+
+    // Exposes guest-side bindings for the desktop-integration plugin
+    //
+    // (c) Copyright 2026 Liminal HQ, Scott Morris
+    // SPDX-License-Identifier: Apache-2.0 OR MIT
+    const PREFIX = 'plugin:desktop-integration|';
+    function cmd(name, args) {
+        return core.invoke(`${PREFIX}${name}`, args);
+    }
+    const desktopIntegration = {
+        /**
+         * Returns true once the portal BindShortcuts call has completed successfully.
+         * On X11 this is always true immediately after startup.
+         * Use this as a race guard after registering the shortcut-binding-result listener.
+         */
+        checkShortcutBindingComplete: () => cmd('check_shortcut_binding_complete'),
+        /**
+         * Returns the error message if BindShortcuts failed, or null if still pending
+         * or successful. Use this as a race guard after registering the
+         * shortcut-binding-result listener — complements checkShortcutBindingComplete.
+         */
+        checkShortcutBindingError: () => cmd('check_shortcut_binding_error'),
+    };
+
+    exports.desktopIntegration = desktopIntegration;
+
+    return exports;
+
+})({}, __TAURI__.core);
+Object.defineProperty(window.__TAURI__, 'desktopIntegration', { value: __TAURI_PLUGIN_DESKTOP_INTEGRATION__ }) }

--- a/plugins/desktop-integration/build.rs
+++ b/plugins/desktop-integration/build.rs
@@ -1,0 +1,13 @@
+// Generates plugin metadata and permission manifests for desktop integration
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+const COMMANDS: &[&str] = &[
+    "check_shortcut_binding_complete",
+    "check_shortcut_binding_error",
+];
+
+fn main() {
+    tauri_plugin::Builder::new(COMMANDS).build();
+}

--- a/plugins/desktop-integration/guest-js/index.ts
+++ b/plugins/desktop-integration/guest-js/index.ts
@@ -1,0 +1,28 @@
+// Exposes guest-side bindings for the desktop-integration plugin
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+import { invoke } from '@tauri-apps/api/core';
+
+const PREFIX = 'plugin:desktop-integration|';
+
+function cmd<T>(name: string, args?: Record<string, unknown>): Promise<T> {
+	return invoke<T>(`${PREFIX}${name}`, args);
+}
+
+export const desktopIntegration = {
+	/**
+	 * Returns true once the portal BindShortcuts call has completed successfully.
+	 * On X11 this is always true immediately after startup.
+	 * Use this as a race guard after registering the shortcut-binding-result listener.
+	 */
+	checkShortcutBindingComplete: () => cmd<boolean>('check_shortcut_binding_complete'),
+
+	/**
+	 * Returns the error message if BindShortcuts failed, or null if still pending
+	 * or successful. Use this as a race guard after registering the
+	 * shortcut-binding-result listener — complements checkShortcutBindingComplete.
+	 */
+	checkShortcutBindingError: () => cmd<string | null>('check_shortcut_binding_error'),
+};

--- a/plugins/desktop-integration/package.json
+++ b/plugins/desktop-integration/package.json
@@ -1,0 +1,38 @@
+{
+	"name": "@liminal-hq/plugin-desktop-integration",
+	"version": "0.2.0",
+	"license": "Apache-2.0 OR MIT",
+	"authors": [
+		"Liminal HQ Contributors"
+	],
+	"repository": "https://github.com/liminal-hq/tauri-plugins-workspace",
+	"type": "module",
+	"types": "./dist-js/index.d.ts",
+	"main": "./dist-js/index.cjs",
+	"module": "./dist-js/index.js",
+	"exports": {
+		"types": "./dist-js/index.d.ts",
+		"import": "./dist-js/index.js",
+		"require": "./dist-js/index.cjs"
+	},
+	"scripts": {
+		"build": "rollup -c",
+		"prepare": "pnpm build"
+	},
+	"files": [
+		"dist-js",
+		"README.md",
+		"LICENSE-MIT",
+		"LICENSE-APACHE",
+		"api-iife.js"
+	],
+	"dependencies": {
+		"@tauri-apps/api": "^2.10.0"
+	},
+	"devDependencies": {
+		"@rollup/plugin-typescript": "^12.1.4",
+		"rollup": "^4.59.1",
+		"tslib": "^2.8.1",
+		"typescript": "^5.9.3"
+	}
+}

--- a/plugins/desktop-integration/package.json
+++ b/plugins/desktop-integration/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@liminal-hq/plugin-desktop-integration",
-	"version": "0.2.0",
+	"version": "0.0.0",
 	"license": "Apache-2.0 OR MIT",
 	"authors": [
 		"Liminal HQ Contributors"

--- a/plugins/desktop-integration/permissions/autogenerated/commands/check_shortcut_binding_complete.toml
+++ b/plugins/desktop-integration/permissions/autogenerated/commands/check_shortcut_binding_complete.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-check-shortcut-binding-complete"
+description = "Enables the check_shortcut_binding_complete command without any pre-configured scope."
+commands.allow = ["check_shortcut_binding_complete"]
+
+[[permission]]
+identifier = "deny-check-shortcut-binding-complete"
+description = "Denies the check_shortcut_binding_complete command without any pre-configured scope."
+commands.deny = ["check_shortcut_binding_complete"]

--- a/plugins/desktop-integration/permissions/autogenerated/commands/check_shortcut_binding_error.toml
+++ b/plugins/desktop-integration/permissions/autogenerated/commands/check_shortcut_binding_error.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-check-shortcut-binding-error"
+description = "Enables the check_shortcut_binding_error command without any pre-configured scope."
+commands.allow = ["check_shortcut_binding_error"]
+
+[[permission]]
+identifier = "deny-check-shortcut-binding-error"
+description = "Denies the check_shortcut_binding_error command without any pre-configured scope."
+commands.deny = ["check_shortcut_binding_error"]

--- a/plugins/desktop-integration/permissions/autogenerated/reference.md
+++ b/plugins/desktop-integration/permissions/autogenerated/reference.md
@@ -1,0 +1,70 @@
+## Default Permission
+
+Default permissions for the desktop-integration plugin
+
+#### This default permission set includes the following:
+
+- `allow-check-shortcut-binding-complete`
+- `allow-check-shortcut-binding-error`
+
+## Permission Table
+
+<table>
+<tr>
+<th>Identifier</th>
+<th>Description</th>
+</tr>
+
+
+<tr>
+<td>
+
+`desktop-integration:allow-check-shortcut-binding-complete`
+
+</td>
+<td>
+
+Enables the check_shortcut_binding_complete command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`desktop-integration:deny-check-shortcut-binding-complete`
+
+</td>
+<td>
+
+Denies the check_shortcut_binding_complete command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`desktop-integration:allow-check-shortcut-binding-error`
+
+</td>
+<td>
+
+Enables the check_shortcut_binding_error command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`desktop-integration:deny-check-shortcut-binding-error`
+
+</td>
+<td>
+
+Denies the check_shortcut_binding_error command without any pre-configured scope.
+
+</td>
+</tr>
+</table>

--- a/plugins/desktop-integration/permissions/default.toml
+++ b/plugins/desktop-integration/permissions/default.toml
@@ -1,0 +1,6 @@
+[default]
+description = "Default permissions for the desktop-integration plugin"
+permissions = [
+  "allow-check-shortcut-binding-complete",
+  "allow-check-shortcut-binding-error",
+]

--- a/plugins/desktop-integration/permissions/schemas/schema.json
+++ b/plugins/desktop-integration/permissions/schemas/schema.json
@@ -1,0 +1,330 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PermissionFile",
+  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+  "type": "object",
+  "properties": {
+    "default": {
+      "description": "The default permission set for the plugin",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DefaultPermission"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
+    },
+    "permission": {
+      "description": "A list of inlined permissions",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Permission"
+      }
+    }
+  },
+  "definitions": {
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "platforms": {
+          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "Commands": {
+      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Allowed command.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Denied command, which takes priority.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "Enables the check_shortcut_binding_complete command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-check-shortcut-binding-complete",
+          "markdownDescription": "Enables the check_shortcut_binding_complete command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the check_shortcut_binding_complete command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-check-shortcut-binding-complete",
+          "markdownDescription": "Denies the check_shortcut_binding_complete command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the check_shortcut_binding_error command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-check-shortcut-binding-error",
+          "markdownDescription": "Enables the check_shortcut_binding_error command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the check_shortcut_binding_error command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-check-shortcut-binding-error",
+          "markdownDescription": "Denies the check_shortcut_binding_error command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the desktop-integration plugin\n#### This default permission set includes:\n\n- `allow-check-shortcut-binding-complete`\n- `allow-check-shortcut-binding-error`",
+          "type": "string",
+          "const": "default",
+          "markdownDescription": "Default permissions for the desktop-integration plugin\n#### This default permission set includes:\n\n- `allow-check-shortcut-binding-complete`\n- `allow-check-shortcut-binding-error`"
+        }
+      ]
+    }
+  }
+}

--- a/plugins/desktop-integration/rollup.config.js
+++ b/plugins/desktop-integration/rollup.config.js
@@ -1,0 +1,3 @@
+import { createConfig } from '../../shared/rollup.config.js';
+
+export default createConfig('desktop-integration');

--- a/plugins/desktop-integration/src/lib.rs
+++ b/plugins/desktop-integration/src/lib.rs
@@ -1,0 +1,555 @@
+// Provides desktop-integration helpers for window activation and shortcuts on Linux
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use log::info;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+use tauri::{
+    plugin::{Builder, TauriPlugin},
+    AppHandle, Emitter, Manager, Runtime, WebviewWindow,
+};
+
+#[cfg(target_os = "linux")]
+use gdkx11::functions::x11_get_server_time;
+#[cfg(target_os = "linux")]
+use gtk::glib::object::Cast;
+#[cfg(target_os = "linux")]
+use gtk::prelude::*;
+
+/// Payload emitted on the `shortcut-binding-result` event.
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShortcutBindingResult {
+    pub success: bool,
+    pub error: Option<String>,
+}
+
+/// Plugin-managed state for shortcut registration.
+pub struct ShortcutState {
+    /// Sender to deliver the window identifier to the deferred BindShortcuts call.
+    /// Consumed on the first `set_shortcut_window` call.
+    pub window_tx: Mutex<Option<tokio::sync::oneshot::Sender<Option<ashpd::WindowIdentifier>>>>,
+    /// Set true once `set_shortcut_window` has been called, preventing re-entry.
+    pub window_provided: AtomicBool,
+    /// Set true once the portal BindShortcuts call reports success.
+    /// Always true on X11 (shortcuts are synchronously bound).
+    pub binding_complete: AtomicBool,
+    /// Owns the Wayland portal session and activation listener for process lifetime.
+    /// Dropping it cancels the listener — must NOT be std::mem::forgot.
+    pub wayland_handle: Mutex<Option<tauri_plugin_xdg_portal::global_shortcuts::ShortcutHandle>>,
+    /// The shortcut string currently active on X11, used to restore it if an
+    /// update to a new shortcut fails.
+    pub current_x11_shortcut: Mutex<Option<String>>,
+    /// Non-None once BindShortcuts has returned a failure. Used by the frontend
+    /// race guard to detect a missed shortcut-binding-result error event.
+    pub binding_error: Mutex<Option<String>>,
+    /// Stored shortcut string for retry after failure.
+    pub wayland_bind_shortcut: Mutex<Option<String>>,
+    /// Stored activation callback for retry after failure.
+    pub wayland_bind_on_activated: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
+    /// Stored portal session id for retry after failure. App-supplied, see
+    /// `register_shortcut`.
+    pub wayland_session_id: Mutex<Option<String>>,
+    /// Stored portal session description for retry after failure. App-supplied,
+    /// see `register_shortcut`.
+    pub wayland_session_description: Mutex<Option<String>>,
+}
+
+impl Default for ShortcutState {
+    fn default() -> Self {
+        Self {
+            window_tx: Mutex::new(None),
+            window_provided: AtomicBool::new(false),
+            binding_complete: AtomicBool::new(false),
+            wayland_handle: Mutex::new(None),
+            current_x11_shortcut: Mutex::new(None),
+            binding_error: Mutex::new(None),
+            wayland_bind_shortcut: Mutex::new(None),
+            wayland_bind_on_activated: Mutex::new(None),
+            wayland_session_id: Mutex::new(None),
+            wayland_session_description: Mutex::new(None),
+        }
+    }
+}
+
+pub trait DesktopIntegrationExt<R: Runtime> {
+    /// Request the window manager to activate and focus the given window.
+    /// On X11 this sets `_NET_WM_USER_TIME`; on Wayland this is a no-op
+    /// (focus is compositor-controlled).
+    fn request_desktop_activation_assist(
+        &self,
+        window: &WebviewWindow<R>,
+        source: &'static str,
+        label: &str,
+    );
+
+    /// Register a global shortcut. On X11 the shortcut is bound immediately
+    /// via `tauri-plugin-global-shortcut`. On Wayland the portal session is
+    /// created here and binding is deferred until `set_shortcut_window` is
+    /// called.
+    ///
+    /// `session_id` and `session_description` identify the Wayland portal
+    /// session — `session_id` should be a stable, app-specific string, and
+    /// `session_description` is shown to the user in the compositor's shortcut
+    /// binding dialog. Both are ignored on X11.
+    fn register_shortcut<F>(
+        &self,
+        session_id: &str,
+        session_description: &str,
+        shortcut: &str,
+        on_activated: F,
+    ) where
+        F: Fn() + Send + Sync + 'static;
+
+    /// Trigger the deferred Wayland portal `BindShortcuts` call. Call this
+    /// when the first picker window becomes visible so the portal dialog has a
+    /// context. No-op on X11 or after the first call.
+    ///
+    /// Emits `shortcut-binding-result` once binding resolves.
+    fn set_shortcut_window(&self, window: &WebviewWindow<R>);
+
+    /// Update the registered shortcut to a new key combination.
+    /// On X11 the shortcut is re-registered immediately. On Wayland the
+    /// portal session cannot be updated live — logs a warning instead.
+    fn update_shortcut<F>(&self, shortcut: &str, on_activated: F)
+    where
+        F: Fn() + Send + Sync + 'static;
+
+    /// Returns true if the global shortcut binding has completed.
+    /// Always true on X11. On Wayland, true only after the portal BindShortcuts
+    /// call succeeds.
+    fn is_shortcut_binding_complete(&self) -> bool;
+
+    /// Returns the binding error message if BindShortcuts failed, or None if
+    /// still pending or successful. Used by the frontend race guard to detect a
+    /// missed shortcut-binding-result error event.
+    fn shortcut_binding_error(&self) -> Option<String>;
+}
+
+/// Returns true once the portal BindShortcuts call has completed successfully.
+/// Exposed to the frontend so it can recover from the race where the backend
+/// emitted shortcut-binding-result before the webview listener was registered.
+#[tauri::command]
+fn check_shortcut_binding_complete<R: Runtime>(app: tauri::AppHandle<R>) -> bool {
+    app.is_shortcut_binding_complete()
+}
+
+/// Returns the binding error message if BindShortcuts failed, or null if still
+/// pending or successful. Complements check_shortcut_binding_complete for the
+/// race where the failure event fires before the webview listener is registered.
+#[tauri::command]
+fn check_shortcut_binding_error<R: Runtime>(app: tauri::AppHandle<R>) -> Option<String> {
+    app.shortcut_binding_error()
+}
+
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    Builder::new("desktop-integration")
+        .invoke_handler(tauri::generate_handler![
+            check_shortcut_binding_complete,
+            check_shortcut_binding_error,
+        ])
+        .setup(|app, _api| {
+            app.manage(ShortcutState::default());
+            Ok(())
+        })
+        .build()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn request_x11_user_time<R: Runtime>(
+    _window: &WebviewWindow<R>,
+    source: &'static str,
+    label: &str,
+) {
+    info!("native X11 activation unavailable for {source} label={label}: not Linux");
+}
+
+#[cfg(target_os = "linux")]
+fn request_x11_user_time<R: Runtime>(window: &WebviewWindow<R>, source: &'static str, label: &str) {
+    let gtk_window = match window.gtk_window() {
+        Ok(w) => w,
+        Err(error) => {
+            info!("native X11 activation unavailable for {source} label={label}: {error}");
+            return;
+        }
+    };
+
+    let mut timestamp = gtk::current_event_time();
+    let mut xid = None;
+
+    if let Some(gdk_window) = gtk_window.window() {
+        if let Ok(x11_window) = gdk_window.downcast::<gdkx11::X11Window>() {
+            xid = Some(x11_window.xid());
+
+            let server_time = x11_get_server_time(&x11_window);
+            if server_time != 0 {
+                timestamp = server_time;
+                x11_window.set_user_time(server_time);
+            }
+        }
+    }
+
+    if timestamp == 0 {
+        if let Ok(x11_display) = gtk_window.display().downcast::<gdkx11::X11Display>() {
+            let display_user_time = x11_display.user_time();
+            if display_user_time != 0 {
+                timestamp = display_user_time;
+            }
+        }
+    }
+
+    gtk_window.present_with_time(timestamp);
+    info!(
+        "native X11 activation requested for {source} label={label} timestamp={timestamp} xid={:?}",
+        xid
+    );
+}
+
+fn is_wayland() -> bool {
+    std::env::var_os("WAYLAND_DISPLAY").is_some()
+}
+
+impl<R: Runtime> DesktopIntegrationExt<R> for AppHandle<R> {
+    fn request_desktop_activation_assist(
+        &self,
+        window: &WebviewWindow<R>,
+        source: &'static str,
+        label: &str,
+    ) {
+        let label = label.to_string();
+        let window = window.clone();
+        let window_for_run = window.clone();
+        let fallback_label = label.clone();
+
+        match window_for_run.run_on_main_thread(move || {
+            request_x11_user_time(&window, source, &label);
+        }) {
+            Ok(()) => {}
+            Err(error) => {
+                info!(
+                    "failed to schedule native X11 activation for {source} label={fallback_label}: {error}"
+                );
+            }
+        }
+    }
+
+    fn register_shortcut<F>(
+        &self,
+        session_id: &str,
+        session_description: &str,
+        shortcut: &str,
+        on_activated: F,
+    ) where
+        F: Fn() + Send + Sync + 'static,
+    {
+        let on_activated = Arc::new(on_activated);
+
+        if is_wayland() {
+            self.register_wayland_shortcut(session_id, session_description, shortcut, on_activated);
+        } else {
+            // X11 binds immediately — mark as complete now.
+            self.state::<ShortcutState>()
+                .binding_complete
+                .store(true, Ordering::SeqCst);
+            self.register_x11_shortcut(shortcut, on_activated);
+        }
+    }
+
+    fn set_shortcut_window(&self, _window: &WebviewWindow<R>) {
+        let state = self.state::<ShortcutState>();
+
+        if state.window_provided.swap(true, Ordering::SeqCst) {
+            return;
+        }
+
+        let tx = match state.window_tx.lock().ok().and_then(|mut g| g.take()) {
+            Some(tx) => tx,
+            None => return,
+        };
+
+        // Send None — the portal dialog will appear compositor-placed.
+        // TODO: anchor the dialog to the window by exporting the wl_surface via
+        // xdg-exported-v2 (requires gdk-wayland bindings or manual GDK C FFI).
+        let _ = tx.send(None);
+    }
+
+    fn update_shortcut<F>(&self, shortcut: &str, on_activated: F)
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        if is_wayland() {
+            log::warn!(
+                "Wayland shortcut change requires app restart to take effect (requested: {shortcut})"
+            );
+        } else {
+            use tauri_plugin_global_shortcut::GlobalShortcutExt;
+
+            let previous = self
+                .state::<ShortcutState>()
+                .current_x11_shortcut
+                .lock()
+                .ok()
+                .and_then(|g| g.clone());
+
+            let on_activated = Arc::new(on_activated);
+
+            let _ = self.global_shortcut().unregister_all();
+
+            let oa_new = on_activated.clone();
+            let result =
+                self.global_shortcut()
+                    .on_shortcut(shortcut, move |_app, _shortcut, event| {
+                        if event.state == tauri_plugin_global_shortcut::ShortcutState::Pressed {
+                            oa_new();
+                        }
+                    });
+
+            match result {
+                Ok(()) => {
+                    info!("X11 global shortcut updated to: {shortcut}");
+                    if let Ok(mut g) = self.state::<ShortcutState>().current_x11_shortcut.lock() {
+                        *g = Some(shortcut.to_string());
+                    }
+                }
+                Err(e) => {
+                    log::error!("failed to update X11 shortcut to {shortcut}: {e}");
+                    // Attempt to restore the previous shortcut so the user isn't left
+                    // with no active shortcut for the rest of the session.
+                    if let Some(ref prev) = previous {
+                        let oa_rollback = on_activated.clone();
+                        let rollback = self.global_shortcut().on_shortcut(
+                            prev.as_str(),
+                            move |_app, _shortcut, event| {
+                                if event.state
+                                    == tauri_plugin_global_shortcut::ShortcutState::Pressed
+                                {
+                                    oa_rollback();
+                                }
+                            },
+                        );
+                        match rollback {
+                            Ok(()) => info!("X11 shortcut rolled back to: {prev}"),
+                            Err(e2) => log::error!(
+                                "failed to restore previous shortcut {prev}: {e2}; \
+                                 no shortcut active until app restart"
+                            ),
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn is_shortcut_binding_complete(&self) -> bool {
+        self.state::<ShortcutState>()
+            .binding_complete
+            .load(Ordering::SeqCst)
+    }
+
+    fn shortcut_binding_error(&self) -> Option<String> {
+        self.state::<ShortcutState>()
+            .binding_error
+            .lock()
+            .ok()
+            .and_then(|g| g.clone())
+    }
+}
+
+/// Internal helpers — not part of the public trait.
+trait DesktopIntegrationInternal<R: Runtime> {
+    fn register_wayland_shortcut(
+        &self,
+        session_id: &str,
+        session_description: &str,
+        shortcut: &str,
+        on_activated: Arc<dyn Fn() + Send + Sync>,
+    );
+
+    fn register_x11_shortcut(&self, shortcut: &str, on_activated: Arc<dyn Fn() + Send + Sync>);
+
+    /// Reset state and spawn a fresh binding task so the next `set_shortcut_window`
+    /// call retries the portal BindShortcuts. No-op if retry params were never stored.
+    fn schedule_wayland_bind_retry(&self);
+}
+
+/// Spawns the async task that drives the Wayland portal binding.
+///
+/// Creates a fresh oneshot channel, stores the sender in `ShortcutState`, resets
+/// `window_provided` to false, then spawns the portal task with the receiver.
+/// Called on first registration and after each binding failure to set up for retry.
+fn spawn_wayland_bind_task<R: Runtime>(
+    app: AppHandle<R>,
+    session_id: String,
+    session_description: String,
+    shortcut: String,
+    on_activated: Arc<dyn Fn() + Send + Sync>,
+) {
+    let (window_tx, window_rx) = tokio::sync::oneshot::channel();
+
+    let state = app.state::<ShortcutState>();
+    // Store the sender before resetting window_provided so a concurrent
+    // set_shortcut_window that observes window_provided=false is guaranteed
+    // to find a valid tx in the mutex.
+    if let Ok(mut guard) = state.window_tx.lock() {
+        *guard = Some(window_tx);
+        state.window_provided.store(false, Ordering::SeqCst);
+    }
+
+    let app_for_result = app.clone();
+    let on_binding_result = move |result: Result<(), String>| {
+        let success = result.is_ok();
+        let state = app_for_result.state::<ShortcutState>();
+        if success {
+            state.binding_complete.store(true, Ordering::SeqCst);
+            // Clear any previous failure message so shortcut_binding_error() reflects
+            // the current successful state after a retry.
+            if let Ok(mut g) = state.binding_error.lock() {
+                *g = None;
+            }
+        } else if let Some(msg) = result.as_ref().err() {
+            if let Ok(mut g) = state.binding_error.lock() {
+                *g = Some(msg.clone());
+            }
+            // Reset for retry: next set_shortcut_window will trigger a new attempt.
+            app_for_result.schedule_wayland_bind_retry();
+        }
+        let payload = ShortcutBindingResult {
+            success,
+            error: result.err(),
+        };
+        app_for_result.emit("shortcut-binding-result", payload).ok();
+    };
+
+    tauri::async_runtime::spawn(async move {
+        match tauri_plugin_xdg_portal::global_shortcuts::create_session(
+            &session_id,
+            &session_description,
+            Some(&shortcut),
+            move || on_activated(),
+            on_binding_result,
+            window_rx,
+        )
+        .await
+        {
+            Ok(handle) => {
+                // Keep the handle alive so the portal session and activation
+                // listener remain active.  Dropping it would cancel the shortcut.
+                if let Ok(mut guard) = app.state::<ShortcutState>().wayland_handle.lock() {
+                    *guard = Some(handle);
+                }
+            }
+            Err(e) => {
+                log::error!("failed to create Wayland shortcut session: {e}");
+                let error_str = e.to_string();
+                if let Ok(mut g) = app.state::<ShortcutState>().binding_error.lock() {
+                    *g = Some(error_str.clone());
+                }
+                // Set up for retry before emitting so the race guard sees the error.
+                app.schedule_wayland_bind_retry();
+                app.emit(
+                    "shortcut-binding-result",
+                    ShortcutBindingResult {
+                        success: false,
+                        error: Some(error_str),
+                    },
+                )
+                .ok();
+            }
+        }
+    });
+}
+
+impl<R: Runtime> DesktopIntegrationInternal<R> for AppHandle<R> {
+    fn register_wayland_shortcut(
+        &self,
+        session_id: &str,
+        session_description: &str,
+        shortcut: &str,
+        on_activated: Arc<dyn Fn() + Send + Sync>,
+    ) {
+        let shortcut = shortcut.to_string();
+        let session_id = session_id.to_string();
+        let session_description = session_description.to_string();
+
+        // Store for use by schedule_wayland_bind_retry after a failure.
+        let state = self.state::<ShortcutState>();
+        if let Ok(mut g) = state.wayland_bind_shortcut.lock() {
+            *g = Some(shortcut.clone());
+        }
+        if let Ok(mut g) = state.wayland_bind_on_activated.lock() {
+            *g = Some(Arc::clone(&on_activated));
+        }
+        if let Ok(mut g) = state.wayland_session_id.lock() {
+            *g = Some(session_id.clone());
+        }
+        if let Ok(mut g) = state.wayland_session_description.lock() {
+            *g = Some(session_description.clone());
+        }
+
+        spawn_wayland_bind_task(
+            self.clone(),
+            session_id,
+            session_description,
+            shortcut,
+            on_activated,
+        );
+    }
+
+    fn register_x11_shortcut(&self, shortcut: &str, on_activated: Arc<dyn Fn() + Send + Sync>) {
+        use tauri_plugin_global_shortcut::GlobalShortcutExt;
+
+        info!("registering global shortcut via X11: {shortcut}");
+        let result = self
+            .global_shortcut()
+            .on_shortcut(shortcut, move |_app, _shortcut, event| {
+                if event.state == tauri_plugin_global_shortcut::ShortcutState::Pressed {
+                    on_activated();
+                }
+            });
+
+        match result {
+            Ok(()) => {
+                info!("X11 global shortcut registered: {shortcut}");
+                if let Ok(mut g) = self.state::<ShortcutState>().current_x11_shortcut.lock() {
+                    *g = Some(shortcut.to_string());
+                }
+            }
+            Err(e) => log::error!("failed to register X11 global shortcut: {e}"),
+        }
+    }
+
+    fn schedule_wayland_bind_retry(&self) {
+        let state = self.state::<ShortcutState>();
+        let shortcut = state
+            .wayland_bind_shortcut
+            .lock()
+            .ok()
+            .and_then(|g| g.clone());
+        let on_activated = state
+            .wayland_bind_on_activated
+            .lock()
+            .ok()
+            .and_then(|g| g.clone());
+        let session_id = state.wayland_session_id.lock().ok().and_then(|g| g.clone());
+        let session_description = state
+            .wayland_session_description
+            .lock()
+            .ok()
+            .and_then(|g| g.clone());
+        if let (Some(shortcut), Some(on_activated), Some(session_id), Some(session_description)) =
+            (shortcut, on_activated, session_id, session_description)
+        {
+            spawn_wayland_bind_task(
+                self.clone(),
+                session_id,
+                session_description,
+                shortcut,
+                on_activated,
+            );
+        }
+    }
+}

--- a/plugins/desktop-integration/tsconfig.json
+++ b/plugins/desktop-integration/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "./dist-js",
+		"rootDir": "./guest-js"
+	},
+	"include": ["guest-js/**/*"]
+}

--- a/plugins/xdg-portal/Cargo.toml
+++ b/plugins/xdg-portal/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "tauri-plugin-xdg-portal"
+version = "0.2.0"
+description = "Tauri plugin for xdg-desktop-portal integrations"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+rust-version = { workspace = true }
+repository = { workspace = true }
+build = "build.rs"
+links = "tauri-plugin-xdg-portal"
+
+[package.metadata.platforms.support]
+windows = { level = "none", notes = "xdg-desktop-portal is Linux-only" }
+linux = { level = "full", notes = "Bridges xdg-desktop-portal Settings and GlobalShortcuts interfaces" }
+macos = { level = "none", notes = "xdg-desktop-portal is Linux-only" }
+android = { level = "none", notes = "xdg-desktop-portal is Linux-only" }
+ios = { level = "none", notes = "xdg-desktop-portal is Linux-only" }
+
+[lib]
+name = "tauri_plugin_xdg_portal"
+crate-type = ["staticlib", "cdylib", "rlib"]
+
+[dependencies]
+ashpd = { version = "0.9", default-features = false, features = ["tokio", "wayland"] }
+futures-util = "0.3"
+serde = { workspace = true }
+serde_json = { workspace = true }
+tauri = { workspace = true }
+thiserror = { workspace = true }
+tokio = { version = "1", features = ["macros", "sync"] }
+log = { workspace = true }
+
+[features]
+default = []
+global-shortcuts = []
+remote-desktop = []
+
+[build-dependencies]
+tauri-plugin = { workspace = true, features = ["build"] }

--- a/plugins/xdg-portal/Cargo.toml
+++ b/plugins/xdg-portal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-xdg-portal"
-version = "0.2.0"
+version = "0.0.0"
 description = "Tauri plugin for xdg-desktop-portal integrations"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/plugins/xdg-portal/README.md
+++ b/plugins/xdg-portal/README.md
@@ -1,0 +1,91 @@
+# @liminal-hq/plugin-xdg-portal
+
+Bridges Tauri apps to the Linux `xdg-desktop-portal` D-Bus interfaces, so sandboxed
+and Wayland apps can request system integration (theming, global shortcuts) through
+the standard freedesktop.org portal APIs instead of platform-specific hacks.
+
+## Installation
+
+### Rust
+
+```toml
+[dependencies]
+tauri-plugin-xdg-portal = "0.2"
+
+# Alternatively with Git:
+tauri-plugin-xdg-portal = { git = "https://github.com/liminal-hq/tauri-plugins-workspace", branch = "main" }
+```
+
+### JavaScript
+
+```bash
+pnpm add @liminal-hq/plugin-xdg-portal
+```
+
+## Usage
+
+### Rust
+
+```rust
+fn main() {
+    tauri::Builder::default()
+        .plugin(tauri_plugin_xdg_portal::init())
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}
+```
+
+### JavaScript
+
+```typescript
+import { portal } from '@liminal-hq/plugin-xdg-portal';
+
+const availability = await portal.checkAvailability();
+const theme = await portal.getThemeInfo();
+```
+
+### Global shortcuts (Rust-only)
+
+The `global_shortcuts` module implements the portal `GlobalShortcuts` interface for
+Wayland, where raw keyboard grabs are not available to applications. Binding a
+shortcut through the portal shows a one-time compositor confirmation dialog, so the
+call is asynchronous and needs a parent window once one exists:
+
+```rust
+use tauri_plugin_xdg_portal::global_shortcuts::create_session;
+
+let handle = create_session(
+    "your-app-toggle",       // stable session/shortcut id
+    "Toggle Your App",       // human-readable description shown in the compositor dialog
+    Some("<Alt><Shift>t"),   // GTK/libxkbcommon accelerator format
+    move || { /* shortcut activated */ },
+    move |result| { /* bind result */ },
+    window_id_receiver,
+)
+.await?;
+```
+
+On X11, prefer `tauri-plugin-global-shortcut` directly — the portal path is Wayland-specific.
+See [`@liminal-hq/plugin-desktop-integration`](../desktop-integration) for a helper that
+picks the right path automatically based on session type.
+
+## Permissions
+
+This plugin requires these permissions:
+
+- `allow-check-availability`: Grants access to `check_availability`
+- `allow-get-theme-info`: Grants access to `get_theme_info`
+
+## Platform Support
+
+| Platform | Support Level | Notes                                           |
+| -------- | ------------- | ----------------------------------------------- |
+| Windows  | None          | `xdg-desktop-portal` is Linux-only              |
+| Linux    | Full          | Bridges Settings and GlobalShortcuts interfaces |
+| macOS    | None          | `xdg-desktop-portal` is Linux-only              |
+| Android  | None          | `xdg-desktop-portal` is Linux-only              |
+| iOS      | None          | `xdg-desktop-portal` is Linux-only              |
+
+## Licence
+
+Apache-2.0 OR MIT

--- a/plugins/xdg-portal/README.md
+++ b/plugins/xdg-portal/README.md
@@ -10,7 +10,7 @@ the standard freedesktop.org portal APIs instead of platform-specific hacks.
 
 ```toml
 [dependencies]
-tauri-plugin-xdg-portal = "0.2"
+tauri-plugin-xdg-portal = "0.1"
 
 # Alternatively with Git:
 tauri-plugin-xdg-portal = { git = "https://github.com/liminal-hq/tauri-plugins-workspace", branch = "main" }

--- a/plugins/xdg-portal/SPEC.md
+++ b/plugins/xdg-portal/SPEC.md
@@ -1,0 +1,137 @@
+# Project Specification: tauri-plugin-xdg-portal
+
+## 1. Overview
+
+`tauri-plugin-xdg-portal` is a native Rust plugin for the Tauri framework designed to bridge the gap between Tauri applications and the Linux `xdg-desktop-portal` D-Bus interfaces.
+
+While Tauri provides cross-platform APIs, modern Linux environments (specifically Wayland and sandboxed formats like Flatpak and Snap) heavily restrict direct system access for security reasons. This plugin allows Tauri applications to securely request system resources (Global Shortcuts, Screen Casting, Input Injection, etc.) by communicating directly with the user's Desktop Environment (GNOME, KDE Plasma, Hyprland) via standard freedesktop.org portal APIs.
+
+## 2. Workspace Integration & Architecture
+
+This plugin is designed to be housed within a generic Tauri plugin workspace monorepo.
+
+### 2.1 Crate Structure
+
+- `src/`: The Rust backend handling D-Bus communication and defining the Tauri IPC commands.
+- `guest-js/`: The TypeScript source files that define the `js-guest` bindings. This creates the clean, typed API that the frontend webview interacts with.
+- `dist-js/`: The compiled JavaScript output (the actual `js-guest` module imported by the frontend).
+- `bindings/`: Automatically generated TypeScript bindings from Rust structs (using `ts-rs` or Tauri's native type generation) to ensure type safety between Rust and JS.
+- `permissions/`: Configuration files defining the security boundaries for the IPC commands.
+
+### 2.2 Tech Stack & Dependencies
+
+- **Rust:**
+  - `ashpd`: The premier Rust wrapper for the XDG Desktop Portal D-Bus API. This drastically simplifies interacting with portals compared to writing raw `zbus` D-Bus calls.
+  - `tauri`: Core framework API for plugin builders.
+  - `serde` / `serde_json`: For serialising payload data between the webview and Rust.
+- **TypeScript:**
+  - `@tauri-apps/api`: To handle IPC `invoke` calls back to the Rust plugin.
+
+## 3. Supported XDG Portals (Feature Roadmap)
+
+The plugin will be modular, allowing developers to enable specific portals via Cargo feature flags to keep binary sizes minimal.
+
+### Phase 1: Core Emoji Picker Requirements
+
+- **`org.freedesktop.portal.GlobalShortcuts`**: Securely register global keybindings. The portal handles prompting the user to allow the shortcut and notifies the app when triggered, bypassing Wayland's keylogger protections.
+- **`org.freedesktop.portal.RemoteDesktop`**: Used for input injection (simulating keystrokes). This portal allows the app to request a session to inject keyboard and mouse events into the Wayland compositor securely.
+
+### Phase 2: Extended Desktop Capabilities
+
+- **`org.freedesktop.portal.ScreenCast` & `Screenshot`**: Securely capture window or monitor contents without raw X11/Wayland buffer access.
+- **`org.freedesktop.portal.Background`**: Request permission to run in the background or autostart on system boot (crucial for utility apps).
+- **`org.freedesktop.portal.Settings`**: Read system-wide user preferences (e.g., colour scheme, accent colours, default fonts) directly from the DE.
+
+### Out of Scope (Handled by Core Tauri)
+
+To prevent duplication of effort and potential D-Bus conflicts, this plugin explicitly omits the following portals:
+
+- **`org.freedesktop.portal.FileChooser`**: Already implemented by `@tauri-apps/plugin-dialog` (via the `xdg-portal` Cargo feature).
+- **`org.freedesktop.portal.OpenURI`**: Handled natively by Tauri's core shell/open functionality.
+
+## 4. API Surface Design
+
+### 4.1 Rust Plugin Initialisation
+
+The plugin will be initialised in the standard Tauri `Builder` pattern. It will gracefully no-op or return errors on non-Linux platforms (using `#[cfg(target_os = "linux")]`), ensuring cross-platform codebases don't break.
+
+```rust
+// In a Tauri app's main.rs
+tauri::Builder::default()
+    .plugin(tauri_plugin_xdg_portal::init())
+    .run(tauri::generate_context!())
+    .expect("error while running tauri application");
+```
+
+### 4.2 TypeScript API Example (`guest-js`)
+
+The `guest-js` frontend will have strongly-typed promises to interact with the portals.
+
+```ts
+import { globalShortcuts, remoteDesktop } from 'tauri-plugin-xdg-portal';
+
+// 1. Registering a Wayland-safe Global Shortcut
+async function setupShortcut() {
+	try {
+		const session = await globalShortcuts.bind({
+			id: 'open-emoji-picker',
+			description: 'Trigger the global emoji picker',
+			preferredTrigger: 'Alt+Shift+E',
+		});
+
+		session.onTriggered(() => {
+			console.log('Shortcut activated by Wayland Compositor!');
+		});
+	} catch (e) {
+		console.error('Portal request denied or unavailable', e);
+	}
+}
+
+// 2. Injecting Text via RemoteDesktop Portal
+async function injectEmoji(emoji: string) {
+	const session = await remoteDesktop.createSession();
+	await session.injectText(emoji);
+	await session.close();
+}
+```
+
+### 4.3 Security & Permissions (`default.toml`)
+
+Tauri v2 relies on a strict capability system. The plugin must define its IPC permissions in the `permissions/` directory. Because XDG portals handle sensitive operations, this plugin follows a **secure-by-default** model.
+
+- **`permissions/default.toml`**: The default permissions granted when an application includes this plugin's default capability. This should **only** expose harmless utility commands (e.g., checking if a portal is available):
+
+```toml
+[default]
+description = "Default permissions for the XDG Portal plugin"
+permissions = [
+    "allow-check-availability"
+]
+```
+
+- **Opt-in Permissions**: Powerful, potentially dangerous portals should be separated into their own permission files (e.g., `permissions/global-shortcuts.toml`, `permissions/remote-desktop.toml`). The app developer must explicitly add these to their app's `capabilities` configuration to use them:
+
+```toml
+# Example: permissions/global-shortcuts.toml
+[[permission]]
+identifier = "allow-bind-shortcut"
+description = "Enables the ability to request a Global Shortcut via the XDG Portal"
+commands.allow = [
+    "bind_global_shortcut",
+    "unbind_global_shortcut"
+]
+```
+
+## 5. Known Challenges & Edge Cases
+
+1. **Asynchronous Portal Prompts:** Unlike standard APIs, XDG portal requests often trigger native UI dialogs (e.g., "Do you want to allow this app to register a shortcut?"). The Rust backend must heavily rely on async tasks and avoid blocking the main Tauri thread while waiting for user interaction.
+2. **Differing DE Implementations:** While the `xdg-desktop-portal` API is standard, backends (GNOME vs. KDE) sometimes implement features differently or have bugs. The plugin should handle unsupported feature errors gracefully.
+3. **Session Management:** Portals like `GlobalShortcuts` and `RemoteDesktop` require maintaining an active D-Bus "Session" object. The Rust state manager will need to hold these session tokens securely in memory so they can be closed or reused.
+
+## 6. Development Milestones
+
+- [ ] **Milestone 1: Scaffold Workspace.** Set up the generic plugin workspace, configure the Rust crate to compile only on Linux, configure the `guest-js` build steps, and define initial `default.toml` permissions.
+- [ ] **Milestone 2: Integrate `ashpd`.** Add the `ashpd` dependency and establish a basic D-Bus connection to the central portal service. Implement a simple ping/read of the `Settings` portal to verify connectivity.
+- [ ] **Milestone 3: Global Shortcuts Portal.** Implement the `GlobalShortcuts` interface. Create the Rust command to request the binding, the IPC layer, and the TS frontend wrapper. Test on GNOME Wayland.
+- [ ] **Milestone 4: Remote Desktop Portal (Input).** Implement the `RemoteDesktop` interface to allow programmatic injection of text. This fulfills the final requirement for the overarching Emoji Picker project.
+- [ ] **Milestone 5: Documentation & Release.** Document the feature flags, write setup instructions for Tauri developers, and publish (optionally) to crates.io / npm.

--- a/plugins/xdg-portal/api-iife.js
+++ b/plugins/xdg-portal/api-iife.js
@@ -1,0 +1,23 @@
+if ('__TAURI__' in window) {
+var __TAURI_PLUGIN_XDG_PORTAL__ = (function (exports, core) {
+    'use strict';
+
+    // Exposes typed guest-side wrappers for plugin command invocation
+    //
+    // (c) Copyright 2026 Liminal HQ, Scott Morris
+    // SPDX-License-Identifier: Apache-2.0 OR MIT
+    const PREFIX = 'plugin:xdg-portal|';
+    function cmd(name, args) {
+        return core.invoke(`${PREFIX}${name}`, args);
+    }
+    const portal = {
+        checkAvailability: () => cmd('check_availability'),
+        getThemeInfo: () => cmd('get_theme_info'),
+    };
+
+    exports.portal = portal;
+
+    return exports;
+
+})({}, __TAURI__.core);
+Object.defineProperty(window.__TAURI__, 'xdgPortal', { value: __TAURI_PLUGIN_XDG_PORTAL__ }) }

--- a/plugins/xdg-portal/build.rs
+++ b/plugins/xdg-portal/build.rs
@@ -1,0 +1,12 @@
+// Generates plugin metadata and permission manifests for commands
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+const COMMANDS: &[&str] = &["check_availability", "get_theme_info"];
+
+fn main() {
+    tauri_plugin::Builder::new(COMMANDS)
+        .global_api_script_path("./api-iife.js")
+        .build();
+}

--- a/plugins/xdg-portal/guest-js/index.ts
+++ b/plugins/xdg-portal/guest-js/index.ts
@@ -1,0 +1,42 @@
+// Exposes typed guest-side wrappers for plugin command invocation
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+import { invoke } from '@tauri-apps/api/core';
+
+type AvailabilityInfo = {
+	isLinux: boolean;
+	sandboxed: boolean;
+	portalAvailable: boolean;
+};
+
+type ColourScheme = 'no-preference' | 'prefer-dark' | 'prefer-light';
+
+type DesktopEnvironment = 'gnome' | 'kde' | 'cinnamon' | 'mate' | 'xfce' | 'unknown';
+
+type AccentColour = {
+	r: number;
+	g: number;
+	b: number;
+};
+
+type ThemeInfo = {
+	colourScheme: ColourScheme;
+	accentColour: AccentColour | null;
+	highContrast: boolean;
+	desktopEnvironment: DesktopEnvironment;
+};
+
+const PREFIX = 'plugin:xdg-portal|';
+
+function cmd<T>(name: string, args?: Record<string, unknown>): Promise<T> {
+	return invoke<T>(`${PREFIX}${name}`, args);
+}
+
+export const portal = {
+	checkAvailability: () => cmd<AvailabilityInfo>('check_availability'),
+	getThemeInfo: () => cmd<ThemeInfo>('get_theme_info'),
+};
+
+export type { ThemeInfo, ColourScheme, DesktopEnvironment, AccentColour };

--- a/plugins/xdg-portal/package.json
+++ b/plugins/xdg-portal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@liminal-hq/plugin-xdg-portal",
-	"version": "0.2.0",
+	"version": "0.0.0",
 	"license": "Apache-2.0 OR MIT",
 	"authors": [
 		"Liminal HQ Contributors"

--- a/plugins/xdg-portal/package.json
+++ b/plugins/xdg-portal/package.json
@@ -1,0 +1,38 @@
+{
+	"name": "@liminal-hq/plugin-xdg-portal",
+	"version": "0.2.0",
+	"license": "Apache-2.0 OR MIT",
+	"authors": [
+		"Liminal HQ Contributors"
+	],
+	"repository": "https://github.com/liminal-hq/tauri-plugins-workspace",
+	"type": "module",
+	"types": "./dist-js/index.d.ts",
+	"main": "./dist-js/index.cjs",
+	"module": "./dist-js/index.js",
+	"exports": {
+		"types": "./dist-js/index.d.ts",
+		"import": "./dist-js/index.js",
+		"require": "./dist-js/index.cjs"
+	},
+	"scripts": {
+		"build": "rollup -c",
+		"prepare": "pnpm build"
+	},
+	"files": [
+		"dist-js",
+		"README.md",
+		"LICENSE-MIT",
+		"LICENSE-APACHE",
+		"api-iife.js"
+	],
+	"dependencies": {
+		"@tauri-apps/api": "^2.10.0"
+	},
+	"devDependencies": {
+		"@rollup/plugin-typescript": "^12.1.4",
+		"rollup": "^4.59.1",
+		"tslib": "^2.8.1",
+		"typescript": "^5.9.3"
+	}
+}

--- a/plugins/xdg-portal/permissions/autogenerated/commands/check_availability.toml
+++ b/plugins/xdg-portal/permissions/autogenerated/commands/check_availability.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-check-availability"
+description = "Enables the check_availability command without any pre-configured scope."
+commands.allow = ["check_availability"]
+
+[[permission]]
+identifier = "deny-check-availability"
+description = "Denies the check_availability command without any pre-configured scope."
+commands.deny = ["check_availability"]

--- a/plugins/xdg-portal/permissions/autogenerated/commands/get_theme_info.toml
+++ b/plugins/xdg-portal/permissions/autogenerated/commands/get_theme_info.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-get-theme-info"
+description = "Enables the get_theme_info command without any pre-configured scope."
+commands.allow = ["get_theme_info"]
+
+[[permission]]
+identifier = "deny-get-theme-info"
+description = "Denies the get_theme_info command without any pre-configured scope."
+commands.deny = ["get_theme_info"]

--- a/plugins/xdg-portal/permissions/autogenerated/reference.md
+++ b/plugins/xdg-portal/permissions/autogenerated/reference.md
@@ -1,0 +1,70 @@
+## Default Permission
+
+Default permissions for the xdg-portal plugin
+
+#### This default permission set includes the following:
+
+- `allow-check-availability`
+- `allow-get-theme-info`
+
+## Permission Table
+
+<table>
+<tr>
+<th>Identifier</th>
+<th>Description</th>
+</tr>
+
+
+<tr>
+<td>
+
+`xdg-portal:allow-check-availability`
+
+</td>
+<td>
+
+Enables the check_availability command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`xdg-portal:deny-check-availability`
+
+</td>
+<td>
+
+Denies the check_availability command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`xdg-portal:allow-get-theme-info`
+
+</td>
+<td>
+
+Enables the get_theme_info command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`xdg-portal:deny-get-theme-info`
+
+</td>
+<td>
+
+Denies the get_theme_info command without any pre-configured scope.
+
+</td>
+</tr>
+</table>

--- a/plugins/xdg-portal/permissions/default.toml
+++ b/plugins/xdg-portal/permissions/default.toml
@@ -1,0 +1,6 @@
+[default]
+description = "Default permissions for the xdg-portal plugin"
+permissions = [
+  "allow-check-availability",
+  "allow-get-theme-info",
+]

--- a/plugins/xdg-portal/permissions/schemas/schema.json
+++ b/plugins/xdg-portal/permissions/schemas/schema.json
@@ -1,0 +1,330 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PermissionFile",
+  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+  "type": "object",
+  "properties": {
+    "default": {
+      "description": "The default permission set for the plugin",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DefaultPermission"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
+    },
+    "permission": {
+      "description": "A list of inlined permissions",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Permission"
+      }
+    }
+  },
+  "definitions": {
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "platforms": {
+          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "Commands": {
+      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Allowed command.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Denied command, which takes priority.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "Enables the check_availability command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-check-availability",
+          "markdownDescription": "Enables the check_availability command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the check_availability command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-check-availability",
+          "markdownDescription": "Denies the check_availability command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the get_theme_info command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-get-theme-info",
+          "markdownDescription": "Enables the get_theme_info command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_theme_info command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-get-theme-info",
+          "markdownDescription": "Denies the get_theme_info command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the xdg-portal plugin\n#### This default permission set includes:\n\n- `allow-check-availability`\n- `allow-get-theme-info`",
+          "type": "string",
+          "const": "default",
+          "markdownDescription": "Default permissions for the xdg-portal plugin\n#### This default permission set includes:\n\n- `allow-check-availability`\n- `allow-get-theme-info`"
+        }
+      ]
+    }
+  }
+}

--- a/plugins/xdg-portal/rollup.config.js
+++ b/plugins/xdg-portal/rollup.config.js
@@ -1,0 +1,3 @@
+import { createConfig } from '../../shared/rollup.config.js';
+
+export default createConfig('xdg-portal');

--- a/plugins/xdg-portal/src/commands.rs
+++ b/plugins/xdg-portal/src/commands.rs
@@ -1,0 +1,20 @@
+// Implements IPC commands exposed by the XDG portal plugin
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::{
+    error::PortalError,
+    linux,
+    models::{AvailabilityInfo, ThemeInfo},
+};
+
+#[tauri::command]
+pub async fn check_availability() -> Result<AvailabilityInfo, PortalError> {
+    linux::check_availability().await
+}
+
+#[tauri::command]
+pub async fn get_theme_info() -> Result<ThemeInfo, PortalError> {
+    linux::get_theme_info().await
+}

--- a/plugins/xdg-portal/src/error.rs
+++ b/plugins/xdg-portal/src/error.rs
@@ -1,0 +1,23 @@
+// Defines plugin error types for portal command failures
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum PortalError {
+    #[error("unsupported platform: only Linux is supported")]
+    UnsupportedPlatform,
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+impl serde::Serialize for PortalError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}

--- a/plugins/xdg-portal/src/global_shortcuts.rs
+++ b/plugins/xdg-portal/src/global_shortcuts.rs
@@ -1,0 +1,224 @@
+// Implements the GlobalShortcuts portal for Wayland shortcut registration
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::error::PortalError;
+use ashpd::WindowIdentifier;
+use futures_util::StreamExt;
+use log::{error, info, warn};
+
+/// Translates a Tauri-style shortcut string (e.g. `"Alt+Shift+E"`) into the
+/// GTK/libxkbcommon accelerator format expected by the portal (`"<Alt><Shift>e"`).
+fn to_xdg_trigger(shortcut: &str) -> String {
+    let mut result = String::new();
+    let mut key = String::new();
+
+    // Collect parts so we can distinguish a non-trailing empty token (which
+    // represents the "+" key itself, e.g. "Ctrl++" → ["Ctrl","",""]) from a
+    // trailing empty produced by split when the string ends with "+".
+    let parts: Vec<&str> = shortcut.split('+').collect();
+    let last = parts.len().saturating_sub(1);
+
+    for (i, part) in parts.iter().enumerate() {
+        match *part {
+            "Alt" => result.push_str("<Alt>"),
+            "Shift" => result.push_str("<Shift>"),
+            "Ctrl" | "Control" => result.push_str("<Ctrl>"),
+            "Super" | "Meta" => result.push_str("<Super>"),
+            // XKB keysym names are case-sensitive: single-character keys use lowercase,
+            // "space" is lowercase, but named keys (Tab, Return, F1, Left, …) must
+            // preserve their original casing.
+            "Space" => key = "space".to_string(),
+            "" if i < last => {
+                // Non-trailing empty token: the "+" character is the key.
+                key = "plus".to_string();
+            }
+            "" => {} // trailing empty after a final '+', skip
+            other => {
+                key = if other.len() == 1 {
+                    other.to_lowercase()
+                } else {
+                    other.to_string()
+                };
+            }
+        }
+    }
+
+    result.push_str(&key);
+    result
+}
+
+/// Creates a GlobalShortcuts portal session.
+///
+/// `window_rx` must deliver the `WindowIdentifier` for the parent window once
+/// it becomes available — the portal's `BindShortcuts` call is deferred until
+/// then.  Send `None` to bind without a parent window (portal dialog will be
+/// unanchored).
+///
+/// `on_binding_result` is called once binding completes (or fails).
+/// `on_activated` is called each time the shortcut fires.
+///
+/// Returns a `ShortcutHandle`; dropping it cancels the listener and closes the
+/// portal session.
+pub async fn create_session<F, B>(
+    shortcut_id: &str,
+    description: &str,
+    preferred_trigger: Option<&str>,
+    on_activated: F,
+    on_binding_result: B,
+    window_rx: tokio::sync::oneshot::Receiver<Option<WindowIdentifier>>,
+) -> Result<ShortcutHandle, PortalError>
+where
+    // Sync is required so Arc<F> is Send, allowing activation dispatch to an OS
+    // thread rather than blocking the Tokio worker during window creation.
+    F: Fn() + Send + Sync + 'static,
+    B: Fn(Result<(), String>) + Send + 'static,
+{
+    use ashpd::desktop::global_shortcuts::{GlobalShortcuts, NewShortcut};
+
+    let portal = GlobalShortcuts::new().await.map_err(|e| {
+        PortalError::Internal(format!("failed to connect to GlobalShortcuts portal: {e}"))
+    })?;
+
+    let session = portal.create_session().await.map_err(|e| {
+        PortalError::Internal(format!("failed to create GlobalShortcuts session: {e}"))
+    })?;
+
+    let trigger_xdg = preferred_trigger.map(to_xdg_trigger);
+    let shortcut = {
+        let s = NewShortcut::new(shortcut_id, description);
+        if let Some(ref t) = trigger_xdg {
+            s.preferred_trigger(t.as_str())
+        } else {
+            s
+        }
+    };
+
+    let activated_stream = portal
+        .receive_activated()
+        .await
+        .map_err(|e| PortalError::Internal(format!("failed to subscribe to activations: {e}")))?;
+
+    let (cancel_tx, mut cancel_rx) = tokio::sync::oneshot::channel::<()>();
+    let sid = shortcut_id.to_string();
+    // Wrap in Arc so we can clone into each per-activation OS thread without
+    // moving or blocking the Tokio worker during WebviewWindowBuilder::build().
+    let on_activated = std::sync::Arc::new(on_activated);
+
+    tokio::spawn(async move {
+        // Keep portal and session alive for the lifetime of this task.
+        let _portal = portal;
+        let _session = session;
+
+        // Wait for the window identifier before binding.
+        let window_id = tokio::select! {
+            result = window_rx => match result {
+                Ok(id) => id.unwrap_or_default(),
+                // Sender dropped without a send (e.g. plugin teardown before first window).
+                Err(_) => {
+                    warn!("shortcut window sender dropped; aborting portal binding");
+                    return;
+                }
+            },
+            _ = &mut cancel_rx => return,
+        };
+
+        let bind_result = _portal
+            .bind_shortcuts(&_session, &[shortcut], &window_id)
+            .await;
+
+        match bind_result {
+            Ok(request) => match request.response() {
+                Ok(resp) => {
+                    if resp.shortcuts().is_empty() {
+                        warn!(
+                            "portal bind succeeded but returned no shortcuts — \
+                             the key combination may already be claimed"
+                        );
+                        on_binding_result(
+                            Err("compositor returned no bound shortcuts".to_string()),
+                        );
+                        return;
+                    }
+                    info!(
+                        "global shortcuts bound: {:?}",
+                        resp.shortcuts().iter().map(|s| s.id()).collect::<Vec<_>>()
+                    );
+                    on_binding_result(Ok(()));
+                }
+                Err(e) => {
+                    error!("bind_shortcuts portal response error: {e}");
+                    on_binding_result(Err(e.to_string()));
+                    return;
+                }
+            },
+            Err(e) => {
+                error!("bind_shortcuts D-Bus call failed: {e}");
+                on_binding_result(Err(e.to_string()));
+                return;
+            }
+        }
+
+        tokio::pin!(activated_stream);
+        loop {
+            tokio::select! {
+                event = activated_stream.next() => {
+                    match event {
+                        Some(event) => {
+                            if event.shortcut_id() == sid {
+                                info!("global shortcut activated: {}", sid);
+                                let f = std::sync::Arc::clone(&on_activated);
+                                std::thread::spawn(move || f());
+                            }
+                        }
+                        // Stream closed (compositor crash, D-Bus drop) — exit cleanly.
+                        None => {
+                            warn!("global shortcut activation stream ended for: {}", sid);
+                            break;
+                        }
+                    }
+                }
+                _ = &mut cancel_rx => {
+                    info!("global shortcut listener cancelled for: {}", sid);
+                    break;
+                }
+            }
+        }
+    });
+
+    Ok(ShortcutHandle { _cancel: cancel_tx })
+}
+
+/// Dropping this handle cancels the shortcut listener and closes the portal session.
+pub struct ShortcutHandle {
+    _cancel: tokio::sync::oneshot::Sender<()>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::to_xdg_trigger;
+
+    #[test]
+    fn translates_single_char_keys_to_lowercase() {
+        assert_eq!(to_xdg_trigger("Alt+Shift+E"), "<Alt><Shift>e");
+        assert_eq!(to_xdg_trigger("Ctrl+Space"), "<Ctrl>space");
+        assert_eq!(to_xdg_trigger("Super+."), "<Super>.");
+    }
+
+    #[test]
+    fn handles_plus_key_in_shortcut() {
+        assert_eq!(to_xdg_trigger("Ctrl++"), "<Ctrl>plus");
+        assert_eq!(to_xdg_trigger("Ctrl+Shift++"), "<Ctrl><Shift>plus");
+        assert_eq!(to_xdg_trigger("+"), "plus");
+    }
+
+    #[test]
+    fn preserves_named_key_case() {
+        assert_eq!(to_xdg_trigger("Alt+Tab"), "<Alt>Tab");
+        assert_eq!(to_xdg_trigger("Ctrl+Return"), "<Ctrl>Return");
+        assert_eq!(to_xdg_trigger("Alt+F1"), "<Alt>F1");
+        assert_eq!(to_xdg_trigger("Ctrl+Left"), "<Ctrl>Left");
+        assert_eq!(to_xdg_trigger("Shift+BackSpace"), "<Shift>BackSpace");
+    }
+}

--- a/plugins/xdg-portal/src/lib.rs
+++ b/plugins/xdg-portal/src/lib.rs
@@ -1,0 +1,24 @@
+// Registers the XDG portal plugin commands for Tauri
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+mod commands;
+mod error;
+pub mod global_shortcuts;
+mod linux;
+mod models;
+
+use tauri::{
+    plugin::{Builder, TauriPlugin},
+    Runtime,
+};
+
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    Builder::new("xdg-portal")
+        .invoke_handler(tauri::generate_handler![
+            commands::check_availability,
+            commands::get_theme_info,
+        ])
+        .build()
+}

--- a/plugins/xdg-portal/src/linux.rs
+++ b/plugins/xdg-portal/src/linux.rs
@@ -1,0 +1,106 @@
+// Provides Linux-specific portal availability and theme detection
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::{
+    error::PortalError,
+    models::{AccentColour, AvailabilityInfo, ColourScheme, DesktopEnvironment, ThemeInfo},
+};
+
+#[cfg(target_os = "linux")]
+pub async fn check_availability() -> Result<AvailabilityInfo, PortalError> {
+    // Minimal Milestone-2 check: query over D-Bus via ashpd-backed call.
+    // If this fails, the desktop portal service is likely unavailable.
+    let proxy = ashpd::desktop::settings::Settings::new()
+        .await
+        .map_err(|e| PortalError::Internal(e.to_string()))?;
+
+    let _ = proxy
+        .color_scheme()
+        .await
+        .map_err(|e| PortalError::Internal(e.to_string()))?;
+
+    Ok(AvailabilityInfo {
+        is_linux: true,
+        sandboxed: ashpd::is_sandboxed().await,
+        portal_available: true,
+    })
+}
+
+#[cfg(not(target_os = "linux"))]
+pub async fn check_availability() -> Result<AvailabilityInfo, PortalError> {
+    Ok(AvailabilityInfo {
+        is_linux: false,
+        sandboxed: false,
+        portal_available: false,
+    })
+}
+
+/// Detect the desktop environment from `XDG_CURRENT_DESKTOP`.
+pub fn detect_desktop_environment() -> DesktopEnvironment {
+    let desktop = std::env::var("XDG_CURRENT_DESKTOP").unwrap_or_default();
+    // XDG_CURRENT_DESKTOP can be colon-separated (e.g. "ubuntu:GNOME")
+    let desktop_upper = desktop.to_uppercase();
+
+    if desktop_upper.contains("GNOME") {
+        DesktopEnvironment::Gnome
+    } else if desktop_upper.contains("KDE") {
+        DesktopEnvironment::Kde
+    } else if desktop_upper.contains("CINNAMON") || desktop_upper.contains("X-CINNAMON") {
+        DesktopEnvironment::Cinnamon
+    } else if desktop_upper.contains("MATE") {
+        DesktopEnvironment::Mate
+    } else if desktop_upper.contains("XFCE") {
+        DesktopEnvironment::Xfce
+    } else {
+        DesktopEnvironment::Unknown
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub async fn get_theme_info() -> Result<ThemeInfo, PortalError> {
+    let settings = ashpd::desktop::settings::Settings::new()
+        .await
+        .map_err(|e| PortalError::Internal(e.to_string()))?;
+
+    // Colour scheme: 0 = no preference, 1 = prefer dark, 2 = prefer light
+    let colour_scheme = match settings.color_scheme().await {
+        Ok(ashpd::desktop::settings::ColorScheme::PreferDark) => ColourScheme::PreferDark,
+        Ok(ashpd::desktop::settings::ColorScheme::PreferLight) => ColourScheme::PreferLight,
+        _ => ColourScheme::NoPreference,
+    };
+
+    // Accent colour: (r, g, b) tuple in 0.0–1.0 sRGB range
+    let accent_colour = settings.accent_color().await.ok().map(|c| AccentColour {
+        r: c.red(),
+        g: c.green(),
+        b: c.blue(),
+    });
+
+    // Contrast: 0 = normal, 1 = high
+    let high_contrast = settings
+        .contrast()
+        .await
+        .map(|c| c == ashpd::desktop::settings::Contrast::High)
+        .unwrap_or(false);
+
+    let desktop_environment = detect_desktop_environment();
+
+    Ok(ThemeInfo {
+        colour_scheme,
+        accent_colour,
+        high_contrast,
+        desktop_environment,
+    })
+}
+
+#[cfg(not(target_os = "linux"))]
+pub async fn get_theme_info() -> Result<ThemeInfo, PortalError> {
+    Ok(ThemeInfo {
+        colour_scheme: ColourScheme::NoPreference,
+        accent_colour: None,
+        high_contrast: false,
+        desktop_environment: DesktopEnvironment::Unknown,
+    })
+}

--- a/plugins/xdg-portal/src/models.rs
+++ b/plugins/xdg-portal/src/models.rs
@@ -1,0 +1,55 @@
+// Defines serialisable models for XDG portal IPC payloads
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AvailabilityInfo {
+    pub is_linux: bool,
+    pub sandboxed: bool,
+    pub portal_available: bool,
+}
+
+/// Colour scheme preference from the desktop portal.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ColourScheme {
+    NoPreference,
+    PreferDark,
+    PreferLight,
+}
+
+/// Desktop environment family, used to select widget style maps.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum DesktopEnvironment {
+    Gnome,
+    Kde,
+    Cinnamon,
+    Mate,
+    Xfce,
+    Unknown,
+}
+
+/// Accent colour as sRGB values in 0.0–1.0 range.
+/// Absent if the desktop does not report an accent colour.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccentColour {
+    pub r: f64,
+    pub g: f64,
+    pub b: f64,
+}
+
+/// Combined theme information from the desktop portal and environment.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThemeInfo {
+    pub colour_scheme: ColourScheme,
+    pub accent_colour: Option<AccentColour>,
+    pub high_contrast: bool,
+    pub desktop_environment: DesktopEnvironment,
+}

--- a/plugins/xdg-portal/tsconfig.json
+++ b/plugins/xdg-portal/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "./dist-js",
+		"rootDir": "./guest-js"
+	},
+	"include": ["guest-js/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,25 @@ importers:
         specifier: ^7.3.1
         version: 7.3.1
 
+  plugins/desktop-integration:
+    dependencies:
+      '@tauri-apps/api':
+        specifier: ^2.10.0
+        version: 2.10.1
+    devDependencies:
+      '@rollup/plugin-typescript':
+        specifier: ^12.1.4
+        version: 12.3.0(rollup@4.59.1)(tslib@2.8.1)(typescript@5.9.3)
+      rollup:
+        specifier: ^4.59.1
+        version: 4.59.1
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   plugins/hdmv:
     dependencies:
       '@tauri-apps/api':
@@ -81,6 +100,25 @@ importers:
         version: 5.9.3
 
   plugins/material-you:
+    dependencies:
+      '@tauri-apps/api':
+        specifier: ^2.10.0
+        version: 2.10.1
+    devDependencies:
+      '@rollup/plugin-typescript':
+        specifier: ^12.1.4
+        version: 12.3.0(rollup@4.59.1)(tslib@2.8.1)(typescript@5.9.3)
+      rollup:
+        specifier: ^4.59.1
+        version: 4.59.1
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  plugins/xdg-portal:
     dependencies:
       '@tauri-apps/api':
         specifier: ^2.10.0
@@ -2029,7 +2067,7 @@ snapshots:
 
   '@covector/command@0.8.0(mocha@10.8.2)':
     dependencies:
-      '@effection/process': 2.1.4(mocha@10.8.2)
+      '@effection/process': 2.1.4
       effection: 2.0.8(mocha@10.8.2)
     transitivePeerDependencies:
       - encoding
@@ -2081,15 +2119,12 @@ snapshots:
       effection: 2.0.8(mocha@10.8.2)
       mocha: 10.8.2
 
-  '@effection/process@2.1.4(mocha@10.8.2)':
+  '@effection/process@2.1.4':
     dependencies:
       cross-spawn: 7.0.6
       ctrlc-windows: 2.2.0
       effection: 2.0.8(mocha@10.8.2)
       shellwords: 0.1.1
-    transitivePeerDependencies:
-      - encoding
-      - mocha
 
   '@effection/stream@2.0.6':
     dependencies:


### PR DESCRIPTION
## Summary
- Adds `tauri-plugin-xdg-portal` and `tauri-plugin-desktop-integration`, promoted from `liminal-hq/emoji-nook` where they were built and are already running in production.
- Restructures guest-js to the workspace convention: `package.json`/`rollup.config.js`/`tsconfig.json` at plugin root (previously nested under `guest-js/`, which `pnpm-workspace.yaml`'s `plugins/*` glob can't see), `dist-js/` + `api-iife.js` build output, `@liminal-hq/plugin-*` package naming.
- Adds `[package.metadata.platforms.support]` (Linux full, everything else none) and gates `gtk`/`gdk`/`gdkx11` plus the one GTK-touching function under `cfg(target_os = "linux")`, so the crate actually compiles on non-Linux targets instead of merely claiming to.
- Fixes the one real app-specific coupling: `desktop-integration`'s Wayland portal session id/description were hardcoded as `"emoji-nook-toggle"` / `"Toggle Emoji Nook"`. Both are now parameters on `register_shortcut`, threaded through to the portal session and preserved across bind retries.
- Registers both in root `Cargo.toml` workspace members, `.changes/config.json` (rust + javascript Covector entries), and the top-level README plugin table.

Not wired into `examples/api` — that app is currently an unused placeholder (declares `material-you` as a dependency but never calls `.plugin()` on it in `lib.rs`), so adding these would just be more unexercised scaffolding rather than real integration coverage.

A companion PR on `liminal-hq/emoji-nook` switches that app to consume these from here via git dependency once this merges.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (all pre-existing `global_shortcuts` unit tests carried over intact)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `pnpm install && pnpm build` (generates `dist-js/` + `api-iife.js` for both plugins)
- [x] `pnpm exec eslint plugins/xdg-portal plugins/desktop-integration`
- [x] `pnpm format:check`
- [x] `pnpm test:js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9UPmCto22Q7QKcsjAF4jm